### PR TITLE
fix: update readme-activity-graph broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ I remain above all a developper appreciating code elegancy and lightness, althou
   </tr>
   <tr>
     <td valign="top" colspan="2">
-      <img src="https://activity-graph.herokuapp.com/graph?username=amimart&hide_border=true&area=true&point=transparent&theme=react-dark" align="center" style="width: 100%;" />
+      <img src="https://github-readme-activity-graph.cyclic.app/graph?username=amimart&hide_border=true&area=true&point=transparent&theme=react-dark" align="center" style="width: 100%;" />
     </td>
   </tr>
 </table>


### PR DESCRIPTION
This PR updates the URL of the `readme-activity-graph` service since the deployment of this project has been moved from <https://activity-graph.herokuapp.com/> to <https://github-readme-activity-graph.cyclic.app/> (see: [project notice](https://github.com/Ashutosh00710/github-readme-activity-graph#%EF%B8%8F-notice-deployment-moved-%EF%B8%8F)). 😉